### PR TITLE
changed the evaluation from Function instance execution to `eval`

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,16 +1,12 @@
+var runEval = require("./evaluate");
+
 function Compiler(loader) {
   this.loader = loader;
   this.logger = loader.Logger.factory("Bitimporter/Compiler");
 
   // Compiler interface
-  this.compile    = this.compile.bind(this);
-  this.canCompile = this.canCompile.bind(this);
+  this.compile = this.compile.bind(this);
 }
-
-
-Compiler.prototype.canCompile = function(/*moduleMeta*/) {
-  return true;
-};
 
 
 /**
@@ -20,27 +16,28 @@ Compiler.prototype.canCompile = function(/*moduleMeta*/) {
  *
  * @returns {Module}
  */
-Compiler.prototype.compile = function(moduleMeta, parentMeta) {
+Compiler.prototype.compile = function(moduleMeta) {
   var loader = this.loader;
   this.logger.log(moduleMeta.name, moduleMeta);
 
   // Evaluation will execute the module meta source, which might call `define`.
   // When that happens, `getDefinitions` will get us the proper module definitions.
-  var evaluated   = evaluate.call(this, moduleMeta, parentMeta);
+  var evaluated   = evaluate(this.loader, moduleMeta);
   var definitions = loader.providers.define.getDefinitions(moduleMeta.name);
 
   if (definitions) {
     definitions.type = loader.Module.Type.AMD;
-    return new loader.Module(definitions);
+    moduleMeta.configure(definitions);
   }
-
-  // If `define` was not called, the we will try to assign the result of the function
-  // call to support IIFE, or exports.
-  moduleMeta.type = evaluated._result ? loader.Module.Type.IIFE : loader.Module.Type.CJS;
-  moduleMeta.code = evaluated._result || evaluated._module.exports;
-  return new loader.Module(moduleMeta);
+  else {
+    // If `define` was not called, the we will try to assign the result of the function
+    // call to support IIFE, or exports.
+    moduleMeta.configure({
+      type: evaluated._result ? loader.Module.Type.IIFE : loader.Module.Type.CJS,
+      code: evaluated._result || evaluated._module.exports
+    });
+  }
 };
-
 
 
 /**
@@ -48,17 +45,11 @@ Compiler.prototype.compile = function(moduleMeta, parentMeta) {
  *
  * @private
  */
-function evaluate(moduleMeta, parentMeta) {
-  var loader  = this.loader;
-  var url     = moduleMeta.url.href;
-  var source  = moduleMeta.source + getSourceUrl(url);
-  var _module = {exports: {}, id: moduleMeta.name, url: url, meta: moduleMeta, parent: parentMeta};
-
-  /* jshint -W061, -W054 */
-  var execute = new Function("System", "define", "require", "module", "exports", "__dirname", "__filename", source);
-  /* jshint +W061, +W054 */
-
-  var result = execute(loader, loader.define, loader.require, _module, _module.exports, moduleMeta.directory, moduleMeta.path);
+function evaluate(loader, moduleMeta) {
+  var sourceUrl = canUseSourceURL(moduleMeta) ? moduleMeta.path : moduleMeta.id;
+  var source    = moduleMeta.source + getSourceUrl(sourceUrl); // We must add a sourceURL to be able to add breakpoints in Chrome.
+  var _module   = {exports: {}, id: moduleMeta.name, meta: moduleMeta};
+  var result    = runEval(loader, loader.define, loader.require, _module, _module.exports, moduleMeta.directory, moduleMeta.path, source);
 
   return {
     _result: result,
@@ -67,13 +58,30 @@ function evaluate(moduleMeta, parentMeta) {
 }
 
 
-/*
+/**
  * Builds a `# sourceURL` string from the URL.
  *
  * @private
  */
 function getSourceUrl(url) {
   return "\n//# sourceURL=" + url;
+}
+
+
+/**
+ * Verifies if a sourceUrl should be the full url of the module or just
+ * the module name. This is to avoid having source maps and the source
+ * url being added be the same url because browsers don't handle that
+ * very well.
+ *
+ * @private
+ */
+function canUseSourceURL(moduleMeta) {
+  if (!moduleMeta.source) {
+    return false;
+  }
+
+  return (moduleMeta.source.indexOf("//# sourceMappingURL=") === -1) && (moduleMeta.source.indexOf("//# sourceURL=") === -1);
 }
 
 

--- a/src/evaluate.js
+++ b/src/evaluate.js
@@ -1,0 +1,12 @@
+// Evaluate in this anonymous method to keep the immediate closure air tight
+// and not allow variables to be leaked to the global object.
+/* jshint unused: false, evil: true */
+module.exports = function(System, define, require, module, exports, __dirname, __filename) {
+  // Really wish Chrome didn't have a bug where executing a function instance causes the stack
+  // to be all crazy when debugging it...  So, we are using `eval` as a last resort.
+  //
+  //var execute = new Function("System", "define", "require", "module", "exports", "__dirname", "__filename", source);
+  //return execute(System, define, require, module, exports, __dirname, __filename);
+  //eval('(new Function("System", "define", "require", "module", "exports", "__dirname", "__filename", source))(System, define, require, module, exports, __dirname, __filename)');
+  eval(arguments[7]);
+};


### PR DESCRIPTION
This was done for now because Chrome has issues figuring out debug line
numbers when calling methods created inside the Function instance.